### PR TITLE
Dev/Camera-crashing

### DIFF
--- a/launch/camera_setup.launch
+++ b/launch/camera_setup.launch
@@ -1,5 +1,6 @@
-<!-- Launch camera feeds -->
 <?xml version="1.0"?>
+
+<!-- Launch camera feeds -->
 <launch> 
     <rosparam command="load" file="$(find camera_usb_driver)/config/camera.yaml"/>
     <node name="send_video_feeds" pkg="camera_usb_driver" type="send_video_feeds" output="screen"/>

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -18,7 +18,7 @@ Camera::Camera(bool view_feeds)
     // If feeds is set to true, then we want to view the video feeds.
     if (view_feeds)
     {
-        ROS_INFO("Receiving video feeds for [%s].", camera_name.c_str());
+        ROS_INFO("Waiting on incoming video feeds from [%s].", camera_name.c_str());
         // Subscriber. Used to view video feeds.
         image_sub = img_tr.subscribe("camera/feeds", 1, &Camera::camera_feeds_callback, this);
     }
@@ -49,9 +49,8 @@ void Camera::camera_feeds_callback(const sensor_msgs::ImageConstPtr &msg)
             cv_bridge::toCvShare(msg, "bgr8")->image;   // Convert ROS msg to BGR image.
         cv::imshow(camera_name, image_frame);           // Display video feeds.
 
-        // If esc key is pressed or frame is empty, close window and shutdown node.
-        char key = (char) cv::waitKey(25);
-        if (key == 27 || image_frame.empty())
+        // If frame is empty, close window and shutdown node.
+        if (image_frame.empty())
         {
             ROS_WARN("Exiting video feeds.");
             ros::shutdown();

--- a/src/view_video_feeds.cpp
+++ b/src/view_video_feeds.cpp
@@ -16,6 +16,17 @@ int main(int argc, char **argv)
 {
     ros::init(argc, argv, "view_video_feeds_node");
     Camera video = Camera(true);   // View video feeds.
-    ros::spin();
+    while (ros::ok())
+    {
+        // ASCII code for esc key is 27.
+        // If key is pressed close window and terminate node.
+        char key = (char) cv::waitKey(27);
+        if (key == 27)
+        {
+            ROS_INFO("Terminating video feeds.");
+            return 1;
+        }
+        ros::spinOnce();
+    }
     return 0;
 }


### PR DESCRIPTION
### Overview
- `camera_setup.launch` file was crashing  due to silly mistake. 
- Fixed the issue.

### Minor Changes
- Modified callback function in `camera.cpp`.
- Modified `view_video_feeds.cpp` file. 

### Action Item(s)
Figure out a good way to terminate the window if empty frame is received. Callback function handles that but that's inside the Camera class. Have to terminate the `view_video_feeds_node` outside of Camera class scope?