### PR TITLE
Dev/fix camera crashes

### DIFF
--- a/config/camera.yaml
+++ b/config/camera.yaml
@@ -5,5 +5,5 @@
 # name: std::string -> set to Camera just to be generic.
 camera:
   fps: 30
-  index: 0
+  index: -1
   name: "Camera"

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -52,7 +52,9 @@ float Camera::get_luminosity_value(cv::Mat image)
     float image_rows = gray_image.rows;
     float image_cols = gray_image.cols;
     float image_size = image_rows * image.cols;
-    float sum_pixel_values = 0;
+
+    // Initialize sum of pixel intensities of image to 0.
+    float sum_pixel_values = 0.0;
 
     // Iterate over all pixel values to get the average pixel intensity.
     // NOTE: Pixel intensities are values between 0 and 255.
@@ -65,8 +67,11 @@ float Camera::get_luminosity_value(cv::Mat image)
         }
     }
 
-    // Get average pixel intensity and normalize.
-    float luminosity_value = (sum_pixel_values / image_size) / 255;
+    // Get average pixel intensity.
+    float avg_pixel_intensity = sum_pixel_values / image_size;
+
+    // Normalize average pixel to give value between 0 and 1.
+    float luminosity_value = (avg_pixel_intensity) / 255;
     return luminosity_value;
 };
 

--- a/src/view_video_feeds.cpp
+++ b/src/view_video_feeds.cpp
@@ -14,7 +14,7 @@
 
 int main(int argc, char **argv)
 {
-    ros::init(argc, argv, "view_video_feeds_node".ros::init_options::AnonymousName);
+    ros::init(argc, argv, "view_video_feeds_node", ros::init_options::AnonymousName);
     Camera video = Camera(true);   // View video feeds.
     while (ros::ok())
     {


### PR DESCRIPTION
### Overview
Camera node was crashing.
- Modified `camera.yaml` to have camera index set to -1. This will allow for the camera to have any index and still work.
- Viewing the camera feeds was crashing because of small type in `view_video_feeds.cpp`.

### Minor Changes
- Cleaned up the code in `camera.cpp` to make logic more understandable and clear.

### Action Item(s)
- Figure out why the index of the camera sometimes swaps between `/dev/video0` and `/dev/video1`.
- Maybe have the logic handle this? Might be too hacky tbh.