### PR TITLE
dev/C-02: V4L2 not working to capture frame

### DIFF
--- a/include/camera_driver/camera.h
+++ b/include/camera_driver/camera.h
@@ -52,7 +52,7 @@ class Camera
      * @return The captured frame as a cv::Mat
      * @throws std::runtime_error if the camera cannot be opened or if the captured frame is empty.
      */
-    static cv::Mat CaptureFrame(cv::VideoCapture &videoCap, int &index);
+    static cv::Mat CaptureFrame(cv::VideoCapture videoCap, int &index);
 
     /**
      * @brief Displays a video frame.

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -23,7 +23,9 @@ Camera::Camera(std::string name, std::string type, int index, int fps)
 }
 
 // Capture a frame from the camera
-cv::Mat Camera::CaptureFrame(cv::VideoCapture &videoCap, int &index)
+// C-02:V4L2 not working to capture frame
+// Cannot pass videoCap obj by reference, not sure why
+cv::Mat Camera::CaptureFrame(cv::VideoCapture videoCap, int &index)
 {
     if (!videoCap.isOpened())
     {


### PR DESCRIPTION
### Overview
[dev/C-02: V4L2 not working to capture frame](https://app.asana.com/0/1205502813096306/1205566488440391/f)
- Video capture not working if `cv::VideoCapture` obj passed by reference when capturing frame.

### Major Changes
- Do not pass video capture obj by reference.

### Minor Changes
- None
- 
### Action Item(s)
- N/A