### PR TITLE
C-05:Update .gitignore to ignore the install directory generated.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -366,5 +366,6 @@ FodyWeavers.xsd
 .vscode/
 build/*
 html/*
+install/*
 logs/*
 out/*


### PR DESCRIPTION
### Problem
[C-05: Ignore install directory](https://app.asana.com/0/1205502813096306/1208298472476125/f)
- When installing package sometimes an install package is generated which should not be tracked by Git.

### Solution
- Update `.gitignore` to ignore `install/*`

### Notes
- N/A