### PR TITLE
C-08: Install Library in Proper Location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 
-project(camera_driver VERSION 2.0.0)
+project(camera_driver VERSION 2.0.1)
 
 find_package(OpenCV 4 REQUIRED)
 find_package(OpenMP REQUIRED)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Camera Driver package relies on the following dependency:
 
 ## Version
 
-Current Version: 2.0.0
+Current Version: 2.0.1
 
 ## Building the Package
 

--- a/src/camera_driver/src/CMakeLists.txt
+++ b/src/camera_driver/src/CMakeLists.txt
@@ -20,6 +20,6 @@ install(TARGETS ${PROJECT_NAME}
 )
 # Specify headers to install
 install(DIRECTORY ../include/
-    DESTINATION include
+    DESTINATION include/${PROJECT_NAME}
     FILES_MATCHING PATTERN "*.h"
 )


### PR DESCRIPTION
### Problem
[C-08: Install library in proper location](https://app.asana.com/0/1205502813096306/1208369471222250/f)
- Library is being installed in the incorrect destination

### Solution
- Update `camera_driver/src/camera_driver/src/CMakeLists.txt` to install in `/usr/local/include/camera_driver/` for Linux OS.

### Notes
- Works fine with Windows OS.
- Update package version